### PR TITLE
Unbind scroll event option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,9 @@ $('.selector').infinitescroll({
 	pixelsFromNavToBottom: undefined,
 	path: undefined, // Can either be an array of URL parts (e.g. ["/page/", "/"]) or a function that accepts the page number and returns a URL
 	prefill: false, // When the document is smaller than the window, load data until the document is larger or links are exhausted
-	maxPage:undefined // to manually control maximum page (when maxPage is undefined, maximum page limitation is not work)
+	maxPage:undefined, // to manually control maximum page (when maxPage is undefined, maximum page limitation is not work)
+	unbindWhenDone: true  // This avoids triggering of events when there is no more pages to load.
+	                      // Set it to false when you have more than one infinite scroll in the same page.
 });
 ```
 

--- a/jquery.infinitescroll.js
+++ b/jquery.infinitescroll.js
@@ -63,7 +63,9 @@
         pixelsFromNavToBottom: undefined,
         path: undefined, // Either parts of a URL as an array (e.g. ["/page/", "/"] or a function that takes in the page number and returns a URL
 		prefill: false, // When the document is smaller than the window, load data until the document is larger or links are exhausted
-        maxPage: undefined // to manually control maximum page (when maxPage is undefined, maximum page limitation is not work)
+        maxPage: undefined, // to manually control maximum page (when maxPage is undefined, maximum page limitation is not work)
+        unbindWhenDone: true // This avoids triggering of events when there is no more pages to load.
+                             // Set it to false when you have more than one infinite scroll in the same page.
 	};
 
     $.infinitescroll.prototype = {
@@ -319,8 +321,9 @@
             opts.state.currPage = 1; // if you need to go back to this instance
             opts.state.isPaused = false;
             opts.state.isBeyondMaxPage = false;
-            this._binding('unbind');
-
+            if (opts.unbindWhenDone) {
+              this._binding('unbind');
+            }
         },
 
         // Load Callback


### PR DESCRIPTION
Had a big problem when using this plugin with multiple infinite scrolls on the same page. The event was unbounded when there were no more pages to load. This pull request gives the user the ability to chose this behaviour. The default is `true` which keeps the plugin working just as it is.